### PR TITLE
Add a `flake.nix`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.direnv
+result

--- a/README.md
+++ b/README.md
@@ -60,6 +60,52 @@ Alternatively, you may build the target locally:
 
 Then, put the `emacs-lsp-booster` binary in your $PATH (e.g. `~/.local/bin`).
 
+#### On nix
+
+There is a flake to simplify installation for nix-based systems.
+To use, add it to your flake inputs, and enable the overlay:
+
+``` nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/«version»";
+    emacs-lsp-booster.url = "github:blahgeek/emacs-lsp-booster";
+    # The emacs-lsp-booster flake itself depends on `nixpkgs` and
+    # `flake-utils`; you might want to make both of these inputs
+    # follow the ones in your configuration.
+    #
+    # emacs-lsp-booster.inputs.nixpkgs.follows = "nixpkgs";
+    # emacs-lsp-booster.inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs = { emacs-lsp-booster, ...}:
+    let my-overlays = {
+          nixpkgs.overlays = [
+            «other-overlays»
+            emacs-lsp-booster.overlays.default
+          ];
+        };
+    in {
+      nixosConfigurations.«hostname» = nixpkgs.lib.nixosSystem rec {
+        system = «system»;
+        modules = [
+          «other-modules»
+          my-overlays
+        ];
+      };
+    };
+}
+```
+
+You can then access the package as `nixpkgs.emacs-lsp-booster`,
+e.g., by putting something like
+
+``` nix
+environment.systemPackages = [ pkgs.emacs-lsp-booster ];
+```
+
+into your `configuration.nix`.
+
 ### Configure `lsp-mode`
 
 > [!NOTE]  

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,29 @@
+{ pkgs, fetchFromGitHub, rustPlatform, lib, ... }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "emacs-lsp-booster";
+  version = "0.1.1";
+
+  cargoSha256 = "sha256-quqhAMKsZorYKFByy2bojGgYR2Ps959Rg/TP8SnwbqM=";
+
+  src = fetchFromGitHub {
+    owner = "blahgeek";
+    repo = pname;
+    rev = "72d718ea35dfd6cdde582ea1824e9a93e084e64e";
+    hash = "sha256-0roQxzQrxcmS2RHQPguBRL76xSErf2hVjuJEyFr5MeM=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    emacs  # For tests
+  ];
+
+  meta = with lib; {
+    description = "Improve performance of Emacs LSP servers by converting JSON to bytecode";
+    homepage = "https://github.com/${src.owner}/${pname}";
+    changelog = "https://github.com/${src.owner}/${pname}/releases/tag/${version}";
+    license = [ licenses.mit ];
+    maintainers = [];
+    mainProgram = "emacs-lsp-booster";
+  };
+
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704194953,
+        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1704593904,
+        "narHash": "sha256-nDoXZDTRdgF3b4n3m011y99nYFewvOl9UpzFvP8Rb3c=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c36fd70a99decfa6e110c86f296a97613034a680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url     = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows     = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = { nixpkgs, rust-overlay, flake-utils, ... }:
+    let overlay = final: prev: { emacs-lsp-booster = final.callPackage ./default.nix { }; };
+    in {
+      overlays.default = overlay;
+    } // flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) overlay ];
+          };
+      in with pkgs; {
+        packages.default = pkgs.emacs-lsp-booster;
+
+        devShells.default = mkShell {
+          buildInputs = [
+            rust-bin.stable.latest.default
+            rust-analyzer
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hi, thank you for this project! Wanting to try it out, I created a quick nix package. I feel like sharing this with the world is the right thing to do, so here we go. The flake works for both development (I added `rust-analyzer` for convenience) and installation.

### Commit summary

#### [nix: Add flake](https://github.com/blahgeek/emacs-lsp-booster/commit/7a9b90d2d3f1004577f324b6d8e8a3ec16f58063)

This functions as both a development flake (including `rust-analyzer`), and a package.

- The development flake may be accessed as normal by `nix develop`.

- Additionally, the package can be build and ran with `nix build .` and `nix run .`, respectively.

#### [Add .envrc](https://github.com/blahgeek/emacs-lsp-booster/commit/f565bf9d941e985060a4fada2c9552237e31f19a)

This provides a convenient way to immediately change to the correct environment with direnv.

#### [README: Add nix installation instructions](https://github.com/blahgeek/emacs-lsp-booster/commit/800665ca244c969baa0a142e8de79294dd574ad1)

Related: https://github.com/blahgeek/emacs-lsp-booster/commit/7a9b90d2d3f1004577f324b6d8e8a3ec16f58063