### PR TITLE
lsp server might be in `exec-path` instead of `PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Then, put the `emacs-lsp-booster` binary in your $PATH (e.g. `~/.local/bin`).
              (not (functionp 'json-rpc-connection))  ;; native json-rpc
              (executable-find "emacs-lsp-booster"))
         (progn
+          (let ((command-from-exec-path (executable-find (car orig-result))))
+            (when command-from-exec-path
+                  (setcar orig-result command-from-exec-path)))
           (message "Using emacs-lsp-booster for %s!" orig-result)
           (cons "emacs-lsp-booster" orig-result))
       orig-result)))


### PR DESCRIPTION
`lsp-mode` will happily find lsp servers if they're in `exec-path`. When passing the original command through to `emacs-lsp-booster`, if the command that `lsp-mode` resolved doesn't have a full path, and it's also not in `PATH`, `emacs-lsp-booster` will not be able to execute the original command (as it's not in the `PATH`).

The solution is to ensure that, if the original command's executable is found in `exec-path`, that we use the full path in the command that we pass to `emacs-lsp-booster`.

Motivation: I use `exec-path` to provide executables to Emacs, without those having been added to the `PATH` also. The reason is because I don't want to "pollute" the environment of any shells that I start from within Emacs with paths to dependencies that the shell doesn't need, I want the environment of those shells to be the same as shells started outside of Emacs (barring vars like `TERM`, etc.).