### PR TITLE
Add mise for toolchain management and expand release targets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,27 +2,28 @@ name: Build and test
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'Cargo.*'
+      - "src/**"
+      - "tests/**"
+      - "Cargo.*"
+      - "mise.toml"
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build-and-test:
-
     runs-on: ubuntu-latest
-
     steps:
-    - name: Install Emacs
-      run: sudo apt-get install -y emacs
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose -- --nocapture
+      - uses: actions/checkout@v4
+      - name: Install Emacs
+        run: sudo apt-get update && sudo apt-get install -y emacs
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+      - name: Build
+        run: mise run build
+      - name: Run tests
+        run: mise run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,83 @@ on:
 jobs:
   release:
     name: release ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-musl, x86_64-apple-darwin, x86_64-pc-windows-gnu]
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-14
+            use_cross: false
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-14
+            use_cross: false
+            binary_name: emacs-lsp-booster
+            archive_ext: tar.gz
+          - target: x86_64-pc-windows-gnu
+            os: ubuntu-latest
+            use_cross: true
+            binary_name: emacs-lsp-booster.exe
+            archive_ext: zip
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.4
+      - uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
+      - name: Build with cross
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build native
+        if: ${{ !matrix.use_cross }}
+        run: |
+          rustup target add ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (tar.gz)
+        if: matrix.archive_ext == 'tar.gz'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz ${{ matrix.binary_name }}
+          shasum -a 256 ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz > ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.tar.gz.sha256sum
+
+      - name: Package (zip)
+        if: matrix.archive_ext == 'zip'
+        run: |
+          cd target/${{ matrix.target }}/release
+          zip ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.zip ${{ matrix.binary_name }}
+          shasum -a 256 ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.zip > ../../../${{ matrix.binary_name }}-${{ github.ref_name }}-${{ matrix.target }}.zip.sha256sum
+
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.binary_name }}-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          RUSTTARGET: ${{ matrix.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.mise.local.toml

--- a/README.md
+++ b/README.md
@@ -114,3 +114,19 @@ Huge thanks to @jdtsmith
 ### Advanced usage
 
 Run `emacs-lsp-booster --help` for more options.
+
+### Development
+
+This project uses [mise](https://mise.jdx.dev/) for toolchain management.
+
+1. [Install mise](https://mise.jdx.dev/getting-started.html)
+2. Run `mise install` to set up the Rust toolchain
+3. Install Emacs (needed for integration tests):
+   - macOS: `brew install emacs`
+   - Ubuntu/Debian: `sudo apt-get install emacs`
+4. Common tasks:
+   - `mise run build` — Build the project
+   - `mise run test` — Run all tests
+   - `mise run lint` — Run clippy
+   - `mise run fmt` — Check formatting
+   - `mise run release` — Build release binary

--- a/mise.lock
+++ b/mise.lock
@@ -1,0 +1,3 @@
+[[tools.rust]]
+version = "1.93.0"
+backend = "core:rust"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,31 @@
+[tools]
+rust = "latest"
+
+[tasks.build]
+description = "Build the project"
+run = "cargo build --verbose"
+
+[tasks.test]
+description = "Run all tests"
+depends = ["build"]
+run = "cargo test --verbose -- --nocapture"
+
+[tasks.lint]
+description = "Run clippy linter"
+run = "cargo clippy -- -D warnings"
+
+[tasks.fmt]
+description = "Check formatting"
+run = "cargo fmt -- --check"
+
+[tasks.fmt-fix]
+description = "Fix formatting"
+run = "cargo fmt"
+
+[tasks.ci]
+description = "Run full CI pipeline (build + test)"
+depends = ["build", "test"]
+
+[tasks.release]
+description = "Build release binary for current platform"
+run = "cargo build --release"


### PR DESCRIPTION
I don't know if you are open to changes like this, if not we can just close this PR.

- Add mise.toml with Rust (latest) and build/test/lint/fmt/release tasks
- Update CI to use jdx/mise-action for consistent toolchain versions
- Replace rust-build action with cross (Linux/Windows) and native macOS runners
- Add arm64 targets: aarch64-linux-musl, aarch64-apple-darwin
- Add development setup section to README

Releaese job: https://github.com/djgoku/emacs-lsp-booster/actions/runs/21801523278
Release: https://github.com/djgoku/emacs-lsp-booster/releases/tag/0.0.11
Build and test: https://github.com/djgoku/emacs-lsp-booster/actions/runs/21801299003/job/62897186792

Using eglot + eglot-booster:
```
EGLOT (dot-files-2026-01-19/(toml-ts-mode conf-toml-mode)) 69298   run      *EGLOT (dot-files-2026-01-19/(toml-ts-mode conf-toml-mode)) output* --           Main         emacs-lsp-booster --json-false-value :json-false -- tombi lsp
```

```
% file emacs-lsp-booster 
emacs-lsp-booster: Mach-O 64-bit executable arm64
```
